### PR TITLE
Update GameState docs to Backend PR #333

### DIFF
--- a/spiele/blokus/xml-dokumentation/spielstatus.adoc
+++ b/spiele/blokus/xml-dokumentation/spielstatus.adoc
@@ -21,33 +21,28 @@ Es folgt die Beschreibung des Spielstatus, der vor jeder Zugaufforderung an die 
 [[status]]
 === Status
 
-* `I` Nummer der Farbe, die aktuell an der Reihe ist (1=BLUE, 2=YELLO, 3=RED, 4=GREEN)
 * `Z` aktuelle Zugzahl
 * `R` aktuelle Rundenzahl
 * `P` Spielstein, der in der ersten Runde gelegt werden muss, siehe xref:spielsteine[]
 * `T` Team, welches beginnt (`ONE`, `TWO`)
 * `board` Das Spielbrett, wie in xref:spielbrett[] definiert
 * `blueShapes`, `yellowShapes`, `redShapes`, `greenShapes` Noch nicht gesetzte Spielsteine, siehe xref:undeployed[]
-* `orderedColors` Die Farben in ihrer Zugreihenfolge. Dies beinhaltet nur Farben, die noch im Spiel sind.
 * `first` Name und auch Team des ersten Spielers.
 * `second` Name und auch Team des zweiten Spielers.
 * `lastMove` der zuletzt ausgeführte Zug, siehe xref:last-move[]
-* `startColor` Die Farbe die zuerst gespielt wird.
 
 [source,xml]
 ----
-<state class="state" currentColorIndex="I" turn="Z" round="R" startPiece="P">
+<state class="state" turn="Z" round="R" startPiece="P">
   <startTeam class="team">T</startTeam>
   board
   blueShapes
   yellowShapes
   redShapes
   greenShapes
-  orderedColors
   first
   second
   lastMove
-  startColor
 </state>
 ----
 
@@ -106,31 +101,6 @@ die positive X-Achste nach rechts und die positive Y-Achse nach unten verläuft.
 
 Die nicht gesetzten Steine werden durch `<shape>` Tags in einem `<blueShapes>`, `<yellowShapes>`, `<redShapes>` und `<greenShapes>` Tag dargestellt.
 
-[[orderedColors]]
-=== Farben in Spielreihenfolge
-
-[source,xml]
-----
-<orderedColors>
-  <color>BLUE</color>
-  <color>YELLOW</color>
-  <color>RED</color>
-  <color>GREEN</color>
-</orderedColors>
-----
-
-Dies ist eine beispielhafte Auflistung der Farben, die noch im Spiel sind. Dem Tag `<orderedMoves>` sind Tags vom Typ `<color>` untergeordnet. Diese beinhalten wiederum eine der vier Spielfarben.
-
-[source,xml]
-----
-<orderedColors>
-  <color>BLUE</color>
-  <color>GREEN</color>
-</orderedColors>
-----
-
-Dies ist ein Beispiel für eine Situation in der nur noch blaue Spielsteine und grüne Spielsteine gelegt werden können.
-
 [[first]]
 === Erster Spieler
 
@@ -162,16 +132,6 @@ Dieser Tag beschreibt den zweiten Spieler. Die Struktur ist wie bei xref:first[]
 
 Der vorherige Zug hat die selbe Struktur wie ein xref:zug[], der gesendet wird, ausser dass das Tag `<lastMove>` und nicht `<data>` heisst. Der vorherige Zug wird in jedem Spielstatus angegeben, ausser vor dem ersten Zug.
 
-[[startColor]]
-=== Startende Spielfarbe
-
-[source,xml]
-----
-<startColor>BLUE</startColor>
-----
-
-Der Tag `<startColor>` beinhaltet die Farbe, die im ersten Zug vom ersten Spieler gelegt wird. Hier ist dies die Farbe Blau.
-
 === Beispiel kompletter Spielstatus
 
 Hier ist das XML eines kompletten beispielhaften Spielstatus, wie es der Computerspieler vom Server bekommt:
@@ -180,7 +140,7 @@ Hier ist das XML eines kompletten beispielhaften Spielstatus, wie es der Compute
 ----
 <room roomId="cb3bc426-5c70-48b9-9307-943bc328b503">
   <data class="memento">
-    <state class="state" currentColorIndex="1" turn="1" round="1" startPiece="PENTO_V">
+    <state class="state" turn="1" round="1" startPiece="PENTO_V">
       <startTeam class="team">ONE</startTeam>
       <board>
         <field x="17" y="0" content="BLUE"/>
@@ -281,12 +241,6 @@ Hier ist das XML eines kompletten beispielhaften Spielstatus, wie es der Compute
         <shape>PENTO_Y</shape>
       </greenShapes>
       <lastMoveMono class="linked-hash-map"/>
-      <orderedColors>
-        <color>BLUE</color>
-        <color>YELLOW</color>
-        <color>RED</color>
-        <color>GREEN</color>
-      </orderedColors>
       <first displayName="One">
         <color class="team">ONE</color>
       </first>
@@ -298,7 +252,6 @@ Hier ist das XML eines kompletten beispielhaften Spielstatus, wie es der Compute
           <position x="17" y="0"/>
         </piece>
       </lastMove>
-      <startColor>BLUE</startColor>
     </state>
   </data>
 </room>

--- a/spiele/blokus/xml-dokumentation/spielverlauf.adoc
+++ b/spiele/blokus/xml-dokumentation/spielverlauf.adoc
@@ -86,7 +86,7 @@ Der Server antwortet jeweils mit der WelcomeMessage (xref:welcome-message[]) und
 </room>
 <room roomId="cb3bc426-5c70-48b9-9307-943bc328b503">
   <data class="memento">
-    <state class="state" currentColorIndex="0" turn="0" round="1" startPiece="PENTO_V">
+    <state class="state" turn="0" round="1" startPiece="PENTO_V">
       <startTeam class="team">ONE</startTeam>
       <board/>
       <blueShapes class="linked-hash-set">
@@ -182,19 +182,12 @@ Der Server antwortet jeweils mit der WelcomeMessage (xref:welcome-message[]) und
         <shape>PENTO_Y</shape>
       </greenShapes>
       <lastMoveMono class="linked-hash-map"/>
-      <orderedColors>
-        <color>BLUE</color>
-        <color>YELLOW</color>
-        <color>RED</color>
-        <color>GREEN</color>
-      </orderedColors>
       <first displayName="One">
         <color class="team">ONE</color>
       </first>
       <second displayName="Two">
         <color class="team">TWO</color>
       </second>
-      <startColor>BLUE</startColor>
     </state>
   </data>
 </room>


### PR DESCRIPTION
Note: requires https://github.com/CAU-Kiel-Tech-Inf/backend/pull/333 to be merged

Due to the changes in said PR, a few things could be removed from the XML, including:
* `currentColorIndex`: Each round is four turns long, thus currentColor can be calculated with modulo on total turn count
* `orderedColors`: likewise, orderedColors is now always the same as `Color.values()`
* `startColor`: This was never used anyways, there wasn't even a need to serialise this, ever